### PR TITLE
fix : relocate QEMU example binaries to build directory

### DIFF
--- a/helloworld/qemu/qemu-mps3-an536/qemu.bat
+++ b/helloworld/qemu/qemu-mps3-an536/qemu.bat
@@ -1,2 +1,2 @@
 @echo off
-qemu-system-arm -M mps3-an536 -kernel qemu-mps3-an536.elf -serial stdio -m 512
+qemu-system-arm -M mps3-an536 -kernel ../../../build/arm/qemu/qemu-mps3-an536/qemu-mps3-an536.elf -serial stdio -m 512

--- a/helloworld/qemu/qemu-vexpress-a9/qemu.bat
+++ b/helloworld/qemu/qemu-vexpress-a9/qemu.bat
@@ -1,2 +1,2 @@
 @echo off
-qemu-system-arm -M vexpress-a9 -kernel qemu-vexpress-a9.elf -serial stdio -m 512
+qemu-system-arm -M vexpress-a9 -kernel ../../../build/arm/qemu/qemu-vexpress-a9/qemu-vexpress-a9.elf -serial stdio -m 512

--- a/helloworld/qemu/qemu-virt-aarch64/qemu.bat
+++ b/helloworld/qemu/qemu-virt-aarch64/qemu.bat
@@ -1,2 +1,2 @@
 @echo off
-qemu-system-aarch64 -M virt -cpu cortex-a53 -kernel qemu-virt-aarch64.elf -serial stdio -m 512
+qemu-system-aarch64 -M virt -cpu cortex-a53 -kernel ../../../build/aarch64/qemu/qemu-virt-aarch64/qemu-virt-aarch64.elf -serial stdio -m 512

--- a/helloworld/qemu/qemu-virt-riscv32/qemu.bat
+++ b/helloworld/qemu/qemu-virt-riscv32/qemu.bat
@@ -1,3 +1,3 @@
 @echo off
-qemu-system-riscv32 -machine virt -nographic -m 256M -kernel qemu-virt-riscv32.elf ^
+qemu-system-riscv32 -machine virt -nographic -m 256M -kernel ../../../build/riscv32/qemu/qemu-virt-riscv32/qemu-virt-riscv32.elf ^
 -device virtio-serial-device

--- a/helloworld/qemu/qemu-virt-riscv64/qemu.bat
+++ b/helloworld/qemu/qemu-virt-riscv64/qemu.bat
@@ -1,3 +1,3 @@
 @echo off
-qemu-system-riscv64 -machine virt -nographic -m 256M -kernel qemu-virt-riscv64.elf ^
+qemu-system-riscv64 -machine virt -nographic -m 256M -kernel ../../../build/riscv64/qemu/qemu-virt-riscv64/qemu-virt-riscv64.elf ^
 -device virtio-serial-device

--- a/mkconfigs/qemu/qemu-hello.mk
+++ b/mkconfigs/qemu/qemu-hello.mk
@@ -28,12 +28,13 @@ QEMU_CRTOBJ_DIR = $(TARGET_DIR_ARCH)/qemu/$(QEMU_BOARD)/crtobj
 QEMU_OBJ_DIR = $(TARGET_DIR_ARCH)/qemu/$(QEMU_BOARD)/obj
 QEMU_CRTOBJ_FILES := $(QEMU_CRTOBJ_DIR)/crt0.o
 QEMU_OBJ_FILES := $(patsubst %.c,$(QEMU_OBJ_DIR)/%.o,$(notdir $(QEMU_SRCS)))
+QEMU_ELF_PATH := $(TARGET_DIR_ARCH)/qemu/$(QEMU_BOARD)
 
 QCFLAGS := $(QCFLAGS) $(DEVICE) $(DEFINE) $(DEBUG)
 ASFLAGS := $(ASFLAGS) $(DEVICE) $(DEFINE) $(DEBUG)
 LDFLAGS := -T $(BOARD_PATH)/qemu/$(QEMU_BOARD)/link.ld $(LDFLAGS)
 
-QEMU_TARGET := $(QEMU_BOARD).elf
+QEMU_TARGET := $(QEMU_ELF_PATH)/$(QEMU_BOARD).elf
 
 $(QEMU_CRTOBJ_DIR)/%.o: $(PROJECT_PATH)/crt/$(ARCH)/%.c
 	$(CC) -c $(QEMU_INC) $(QCFLAGS) -o $@ $<
@@ -45,7 +46,7 @@ $(QEMU_OBJ_DIR)/%.o: $(BOARD_PATH)/%.c
 	$(CC) -c $(QEMU_INC) $(QCFLAGS) -o $@ $<
 
 .PHONY:qemu-hello
-qemu-hello: creat_qdir $(BOARD_PATH)/qemu/$(QEMU_BOARD)/$(QEMU_TARGET)
+qemu-hello: creat_qdir $(QEMU_TARGET)
 
 .PHONY: creat_qdir
 creat_qdir:
@@ -57,5 +58,5 @@ else
 	@mkdir -p $(QEMU_OBJ_DIR)
 endif
 
-$(BOARD_PATH)/qemu/$(QEMU_BOARD)/$(QEMU_TARGET): $(QEMU_CRTOBJ_FILES) $(QEMU_OBJ_FILES)
+$(QEMU_TARGET): $(QEMU_CRTOBJ_FILES) $(QEMU_OBJ_FILES)
 	$(CC) -o $@ $(QEMU_OBJ_FILES) $(QEMU_CRTOBJ_FILES) $(LDFLAGS)


### PR DESCRIPTION
# This change moves the QEMU example binaries from the source tree to the build directory. Closes: #58 

Key changes:
- Created dedicated QEMU_ELF_PATH for output binaries
- Updated qemu-hello.mk to generate files in the build directory
- Fixed all qemu.bat scripts to use the new binary locations