### PR TITLE
fix: correct return value in __mlibc_read function

### DIFF
--- a/src/stdio/__mlibc_stdio_impl.c
+++ b/src/stdio/__mlibc_stdio_impl.c
@@ -31,12 +31,12 @@ ssize_t __mlibc_read(FILE *f, unsigned char *buf, size_t buf_size)
     }
     else
     {
+        ret = user_buffer_cnt;
         /* Read to the file buffer */
         file_buffer_cnt = f->buf_size > 0 ? read(f->fd, f->buf, f->buf_size) : 0;
         if(file_buffer_cnt <= 0)
         {
             f->flags |= file_buffer_cnt ? F_ERR : F_EOF;
-            ret = user_buffer_cnt;
         }
         else
         {
@@ -45,7 +45,7 @@ ssize_t __mlibc_read(FILE *f, unsigned char *buf, size_t buf_size)
         }
     }
 
-    return user_buffer_cnt;
+    return ret;
 }
 
 /* 


### PR DESCRIPTION
Closes: #55
Fix the compiler warning "variable 'ret' set but not used" by returning the ret variable instead of user_buffer_cnt.