### PR TITLE
toolchain: Add RISC-V multi-arch support and build system improvements

### DIFF
--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -1,4 +1,8 @@
-target            =             arm-linux-eabi
+arch              =             arm
+abi               =             linux-eabi
+#arch              =             riscv64
+#abi               =             unknown-elf
+target            =             ${arch}-${abi}
 build             =             x86_64-pc-linux-gnu
 ENABLE_MULTILIB   ?= 			1
 
@@ -56,7 +60,10 @@ GCC_CONFIG       +=             --enable-languages=c
 ifeq (${ENABLE_MULTILIB}, 1)
 GCC_CONFIG       +=             --enable-multiarch
 GCC_CONFIG       +=             --enable-multilib
+GCC_CONFIG       +=             --without-newlib
+ifeq (${target}, "arm-linux-eabi")
 GCC_CONFIG       +=             --with-multilib-list=rmprofile
+endif
 else
 GCC_CONFIG       +=             --disable-multilib
 endif
@@ -183,17 +190,33 @@ build_all_target_libgcc:
 	cd ${BUILDDIR}/obj_gcc && ${MAKE}  all-target-libgcc > ${LOGDIR}/log.all-target-libgcc.${host}.make
 
 build_mlibc:
+	(cd "${BUILDDIR}/src_mlibc" && \
+			make \
+			ARCH="${arch}" \
+			CC='${BUILDDIR}/obj_gcc/gcc/xgcc -B ${BUILDDIR}/obj_gcc/gcc' \
+			AR='${BUILDDIR}/obj_binutils/binutils/ar' \
+			TARGET_DIR_ARCH="build/") || exit 1; \
+		mkdir -p "${sysroot}/lib/"; \
+		cp "${BUILDDIR}/src_mlibc/build/libmlibc.a" "${sysroot}/lib/libc.a"; \
+		cp "${BUILDDIR}/src_mlibc/build/crtobj/"*.o "${sysroot}/lib/";
 	@for mlib in ${MULTILIBS}; do \
 		[ $${mlib} = ".;" ] && continue; \
 		mlib_dir=$$(echo "$${mlib}" | cut -d';' -f1); \
 		mlib_flags=$$(echo "$${mlib}" | cut -d';' -f2 | sed 's/@/ -/g'); \
 		raw_arch=$$(echo "$${mlib_dir}" | cut -d'/' -f1); \
-		arch=$$([ "$${raw_arch}" = "thumb" ] && echo "arm" || echo "$${raw_arch}"); \
-		echo "Building $${mlib_dir} (ARCH=$${arch}) with flags: $${mlib_flags}"; \
+		march=$$( \
+		    case $${raw_arch} in \
+		        rv64*) echo "riscv64" ;; \
+		        rv32*) echo "riscv32" ;; \
+		        thumb) echo "arm" ;; \
+		        *)     echo "$${raw_arch}" ;; \
+		    esac \
+		); \
+		echo "Building $${mlib_dir} (ARCH=$${march}) with flags: $${mlib_flags}"; \
 		mkdir -p "${BUILDDIR}/src_mlibc/build/$${mlib_dir}"; \
 		(cd "${BUILDDIR}/src_mlibc" && \
 			make \
-			ARCH="$${arch}" \
+			ARCH="$${march}" \
 			CC='${BUILDDIR}/obj_gcc/gcc/xgcc -B ${BUILDDIR}/obj_gcc/gcc' \
 			AR='${BUILDDIR}/obj_binutils/binutils/ar' \
 			ARCH_FLAGS="$${mlib_flags}" \
@@ -229,6 +252,8 @@ install:
 	cp -r ${BUILDDIR}/src_mlibc/include ${INSTALLDIR}/${target}
 	cd ${BUILDDIR}/obj_gcc       && ${MAKE} DESTDIR=${INSTALLDIR}/            install-strip         > ${LOGDIR}/log.gcc.${host}.install
 	#@echo "Installing multilib libraries..."
+	cp -f ${sysroot}/lib/libc.a ${INSTALLDIR}/${target}/lib/libc.a
+	cp -f ${sysroot}/lib/*.o ${INSTALLDIR}/${target}/lib/
 	@for mlib in ${MULTILIBS}; do \
 		[ $${mlib} = ".;" ] && continue; \
 		mlib_dir=$$(echo "$${mlib}" | cut -d';' -f1); \

--- a/toolchain/README.md
+++ b/toolchain/README.md
@@ -61,7 +61,7 @@
    ```
    # 进入工具链目录（容器内路径已映射）
    cd ~/workspace/toolchain
-   make  # 执行编译，生成ARM工具链
+   make arch=arm abi=linux-eabi  # 执行编译，生成ARM工具链，如果是riscv，使用`make arch=riscv64 abi=unkwown-elf`
    ```
 
 5. **验证编译结果**

--- a/toolchain/patches/gcc-12.2.0/0003-disable-riscv64-gloss.diff
+++ b/toolchain/patches/gcc-12.2.0/0003-disable-riscv64-gloss.diff
@@ -1,0 +1,13 @@
+diff --git a/toolchain/gcc-12.2.0/gcc/config/riscv/elf.h b/toolchain/gcc-12.2.0/gcc/config/riscv/elf.h
+index f0e865d..026b9d9 100644
+--- a/gcc/config/riscv/elf.h
++++ b/gcc/config/riscv/elf.h
+@@ -27,7 +27,7 @@ along with GCC; see the file COPYING3.  If not see
+ /* Link against Newlib libraries, because the ELF backend assumes Newlib.
+    Handle the circular dependence between libc and libgloss. */
+ #undef  LIB_SPEC
+-#define LIB_SPEC "--start-group -lc %{!specs=nosys.specs:-lgloss} --end-group"
++#define LIB_SPEC "--start-group -lc --end-group"
+ 
+ #undef  STARTFILE_SPEC
+ #define STARTFILE_SPEC "crt0%O%s crtbegin%O%s"


### PR DESCRIPTION
This PR introduces RISC-V architecture support and enhances the toolchain build system:

1. **Multi-Architecture Support**:
   - New configurable build options for both ARM and RISC-V (rv32i/rv64i variants)
   - Supports major RISC-V ABIs: rv32imac, rv64imafdc, etc.

2. **Build System Improvements**:
   - Refactored Makefile with architecture detection
   - Fixed libc installation flow
   - Removed libgloss dependency for cleaner RISC-V builds

3. **Documentation**:
   - Added clear build instructions for different architectures